### PR TITLE
Increase upper bound on interfaces to 128

### DIFF
--- a/src/Network/Info.hsc
+++ b/src/Network/Info.hsc
@@ -58,8 +58,8 @@ instance Storable NetworkInterface where
 --   the local computer.
 getNetworkInterfaces :: IO [NetworkInterface]
 getNetworkInterfaces =
-    allocaArray 64 $ \ptr -> do
-    count <- c_get_network_interfaces ptr 64
+    allocaArray 128 $ \ptr -> do
+    count <- c_get_network_interfaces ptr 128
     peekArray (fromIntegral count) ptr
 
 


### PR DESCRIPTION
We hit the limit of 64 interfaces when running a large number of
`docker` containers, each of which created a bridge interface.  This
doubles the limit as a temporary work-around, although a real fix
would be to change the code to handle an arbitrarily large number of
interfaces as memory permits.